### PR TITLE
Change images to absolute paths

### DIFF
--- a/src/Shell.jsx
+++ b/src/Shell.jsx
@@ -6,7 +6,7 @@ export function Shell() {
 
   return (
     <>
-      <header className=" border-2 border-red-300 flex justify-between items-center px-8">
+      <header className="border-2 border-red-300 flex justify-between items-center px-8">
         <Link to="/">Profile</Link>
         <NavBar courseList={allCourses} />
       </header>

--- a/src/components/AnimalIcon.jsx
+++ b/src/components/AnimalIcon.jsx
@@ -65,7 +65,7 @@ const AnimalIcon = ({ imageUrl, text, link}) => {
               style={progressBarStyle}
             />
             <button onClick={handleButtonClick}>
-              <img src={"images/add.png"} alt="Animal" style={imageStyle} />
+              <img src={"/images/add.png"} alt="Animal" style={imageStyle} />
             </button>
           </div>
         </div>

--- a/src/mock-database/data.json
+++ b/src/mock-database/data.json
@@ -1,7 +1,7 @@
 [
   {
     "courseId": "cs1000",
-    "courseAnimal": ["images/DogSad.png", "images/DogNeutral.png", "images/DogHappy.png"],
+    "courseAnimal": ["/images/DogSad.png", "/images/DogNeutral.png", "/images/DogHappy.png"],
     "pet": "Dog",
     "modules": [
       {
@@ -64,7 +64,7 @@
   },
   {
     "courseId": "cs2000",
-    "courseAnimal": ["images/KoalaSad.png", "images/KoalaNeutral.png", "images/KoalaHappy.png"],
+    "courseAnimal": ["/images/KoalaSad.png", "/images/KoalaNeutral.png", "/images/KoalaHappy.png"],
     "pet": "Koala",
     "modules": [
       {
@@ -127,7 +127,7 @@
   },
   {
     "courseId": "cs3000",
-    "courseAnimal": ["images/PigSad.png", "images/PigNeutral.png", "images/PigHappy.png"],
+    "courseAnimal": ["/images/PigSad.png", "/images/PigNeutral.png", "/images/PigHappy.png"],
     "pet": "Pig",
     "modules": [
       {
@@ -190,7 +190,7 @@
   },
   {
     "courseId": "cs4000",
-    "courseAnimal": ["images/CatSad.png", "images/CatNeutral.png", "images/CatHappy.png"],
+    "courseAnimal": ["/images/CatSad.png", "/images/CatNeutral.png", "/images/CatHappy.png"],
     "pet": "Cat",
     "modules": [
       {
@@ -253,7 +253,7 @@
   },
   {
     "courseId": "cs5000",
-    "courseAnimal": ["images/FrogSad.png", "images/FrogNeutral.png", "images/FrogHappy.png"],
+    "courseAnimal": ["/images/FrogSad.png", "/images/FrogNeutral.png", "/images/FrogHappy.png"],
     "pet": "Frog",
     "modules": [
       {


### PR DESCRIPTION
Images and other static assets should use absolute path, i.e. should start with a "slash". This PR adds slashes to image urls in the `data.json` file and to the `images/add.png`